### PR TITLE
Fix the type error of the Uris property of class AriaFile

### DIFF
--- a/AriaNet/Attributes/AriaFile.cs
+++ b/AriaNet/Attributes/AriaFile.cs
@@ -22,6 +22,6 @@ namespace AriaNet.Attributes
         public string Selected { get; set; }
 
         [JsonProperty("uris")]
-        public List<Uri> Uris { get; set; }
+        public List<AriaUri> Uris { get; set; }
     }
 }


### PR DESCRIPTION
The type of the `Uris` property of class `AriaFile` should be `AriaUri` instead of `Uri`. Otherwise, an exception will be thrown during deserialization.